### PR TITLE
Refresh user data: per-user and batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,16 @@ Changelog formatting (http://semver.org/):
 ### Removed (for deprecated features removed in this release)
 -->
 
-## 0.5.0-alpha (:construction: WIP 2019-03-06)
+## 0.6.0-alpha (:construction: WIP 2019-03-07)
+
+### Added
+
+- A title attribute to the "A11y Status" column data in the Users list table to provide the date and time the data was last updated.
+- Method to update an individual user's metadata with their WSU Accessibility Training status from the API as needed.
+- An "immediate action" link in the list of action links displayed for each user row in the WP Users list table that triggers a manual refresh of that user's accessibility training status, along with a method to handle that refresh. The handler validates the request then calls the update individual user metadata method.
+- An admin notice that displays after successfully refreshing a user's accessibility status metadata.
+
+## 0.5.0 (2019-03-06)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,14 +17,23 @@ Changelog formatting (http://semver.org/):
 ### Removed (for deprecated features removed in this release)
 -->
 
-## 0.6.0-alpha (:construction: WIP 2019-03-07)
+## 0.6.0 (:construction: WIP 2019-03-08)
+
+### Fixed
+
+- Several phpcs standards issues.
 
 ### Added
 
+- Methods to add a bulk action option on the Users list table bulk actions dropdown field to refresh accessibility status data from the API for all selected users and to execute that bulk refresh.
 - A title attribute to the "A11y Status" column data in the Users list table to provide the date and time the data was last updated.
 - Method to update an individual user's metadata with their WSU Accessibility Training status from the API as needed.
 - An "immediate action" link in the list of action links displayed for each user row in the WP Users list table that triggers a manual refresh of that user's accessibility training status, along with a method to handle that refresh. The handler validates the request then calls the update individual user metadata method.
 - An admin notice that displays after successfully refreshing a user's accessibility status metadata.
+
+### Changed
+
+- Consolidated all action-related admin notices into one callback method to display success and failure messages for individual and bulk accessibility status update actions.
 
 ## 0.5.0 (2019-03-06)
 

--- a/includes/class-setup.php
+++ b/includes/class-setup.php
@@ -667,22 +667,28 @@ class WSUWP_A11y_Status {
 	public function manage_a11y_status_user_column( $output, $column_name, $user_id ) {
 		if ( 'a11y_status' === $column_name ) {
 			$is_certified = self::is_user_certified( $user_id );
+			$last_checked = self::get_user_a11y_status( $user_id )['last_checked'];
 
 			if ( false === $is_certified ) {
 				if ( self::was_user_certified( $user_id ) ) {
 					$expired = self::get_user_a11y_time_to_expiration( $user_id );
 					$output  = sprintf(
-						'<span class="dashicons-before dashicons-warning notice-error">Expired %1$s ago</span>',
+						'<span title="Updated %1$s" class="dashicons-before dashicons-warning notice-error">Expired %2$s ago</span>',
+						esc_attr( $last_checked ),
 						esc_html( $expired )
 					);
 				} else {
-					$output = '<span class="dashicons-before dashicons-no notice-error">None</span>';
+					$output = sprintf(
+						'<span title="Updated %1$s" class="dashicons-before dashicons-no notice-error">None</span>',
+						esc_attr( $last_checked )
+					);
 				}
 			} elseif ( true === $is_certified ) {
 				$class   = ( self::is_user_a11y_lt_one_month( $user_id ) ) ? '-flag notice-warning' : '-awards notice-success';
 				$expires = self::get_user_a11y_time_to_expiration( $user_id );
 				$output  = sprintf(
-					'<span class="dashicons-before dashicons%1$s">Expires in %2$s</span>',
+					'<span title="Updated %1$s" class="dashicons-before dashicons%2$s">Expires in %3$s</span>',
+					esc_attr( $last_checked ),
 					esc_attr( $class ),
 					esc_html( $expires )
 				);

--- a/includes/class-setup.php
+++ b/includes/class-setup.php
@@ -32,7 +32,7 @@ class WSUWP_A11y_Status {
 	 * @since 0.1.0
 	 * @var string
 	 */
-	protected $version = '0.5.0-alpha';
+	protected $version = '0.6.0';
 
 	/**
 	 * The WSU Accessibility Training API endpoint.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wsuwp-plugin-a11y-status",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/washingtonstateuniversity/wsuwp-plugin-a11y-status"

--- a/src/_css/main.css
+++ b/src/_css/main.css
@@ -2,7 +2,7 @@
 Plugin Name: WSUWP A11y Status
 Author: WSU University Communication, Adam Turner
 Author URI: https://web.wsu.edu/
-Version: 0.5.0-alpha
+Version: 0.6.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 */

--- a/wsuwp-a11y-status.php
+++ b/wsuwp-a11y-status.php
@@ -1,13 +1,13 @@
 <?php
 /*
 Plugin Name: WSUWP A11y Status
-Version: 0.5.0-alpha
+Version: 0.6.0
 Description: A plugin to view users' WSU Accessibility Training status in the Admin area.
 Author: washingtonstateuniversity, Adam Turner
 Author URI: https://github.com/washingtonstateuniversity/
 Plugin URI: https://github.com/washingtonstateuniversity/wsuwp-plugin-a11y-status
 Text Domain: wsuwp-a11y-status
-Requires at least: 3.5
+Requires at least: 4.7
 Tested up to: 5.2.0
 Requires PHP: 5.3
 */


### PR DESCRIPTION
This pull request includes new methods for updating user accessibility training status data from the API on both a per-user and a batch basis, all from the Users screen. This allows administrators to refresh the training status of one or more users manually from the Users screen instead of having to log out and in again to trigger an automatic refresh.

It also includes:

- Fixes to some phpcs coding standards issues
- Consolidation and tuning of the admin notices triggered by user update actions
- Addition of a "last updated" title attribute in the "A11y Status" column in the Users list

Also bumps the required minimum WordPress version up to 4.7.