### PR TITLE
Auto-update data on activate, uninstall, register

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,20 @@ Changelog formatting (http://semver.org/):
 ### Removed (for deprecated features removed in this release)
 -->
 
-## 0.6.0 (:construction: WIP 2019-03-08)
+## 0.7.0 (:construction: WIP 2019-03-11)
+
+### Changed
+
+- Load the plugin on the `plugins_loaded` hook instead of `after_setup_theme`.
+- Refactored singleton instance setup method to use `isset()`.
+
+### Added
+
+- An uninstall method (which fires only when the plugin is deleted from the Plugins admin screen) that removes all plugin data from the from the database.
+- Activation method to fetch API data and populate the user metadata for all users when the plugin is initially activated.
+- An action on the `user_register` hook, which fires immediately after a user is added to the database, to fetch and save accessibility training data for that user.
+
+## 0.6.0 (2019-03-08)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Changelog formatting (http://semver.org/):
 ### Removed (for deprecated features removed in this release)
 -->
 
-## 0.7.0 (:construction: WIP 2019-03-11)
+## 0.7.0 (2019-03-11)
 
 ### Changed
 

--- a/includes/class-setup.php
+++ b/includes/class-setup.php
@@ -32,7 +32,7 @@ class WSUWP_A11y_Status {
 	 * @since 0.1.0
 	 * @var string
 	 */
-	protected $version = '0.6.0';
+	protected $version = '0.7.0';
 
 	/**
 	 * The WSU Accessibility Training API endpoint.

--- a/includes/class-setup.php
+++ b/includes/class-setup.php
@@ -66,10 +66,9 @@ class WSUWP_A11y_Status {
 	 * @return object WSUWP_A11y_Status
 	 */
 	public static function get_instance() {
-		static $instance = null;
+		static $instance;
 
-		// Only set up and activate the plugin if it hasn't already been done.
-		if ( null === $instance ) {
+		if ( ! isset( $instance ) ) {
 			$instance = new WSUWP_A11y_Status();
 		}
 
@@ -91,7 +90,18 @@ class WSUWP_A11y_Status {
 	 * @since 0.1.0
 	 */
 	public static function activate() {
-		// @todo Fetch the API data on plugin activation.
+		if ( ! current_user_can( 'activate_plugins' ) ) {
+			return;
+		}
+
+		$user       = wp_get_current_user();
+		$user_login = $user->user_login;
+
+		// The activation hook fires before the plugin is loaded, so we have get the instance manually.
+		$instance = self::get_instance();
+
+		// Fetch the API data on plugin activation.
+		$instance->update_a11y_status_usermeta( $user_login, $user );
 	}
 
 	/**
@@ -100,7 +110,29 @@ class WSUWP_A11y_Status {
 	 * @since 0.1.0
 	 */
 	public static function deactivate() {
-		// @todo Something.
+		// Nothing for now.
+	}
+
+	/**
+	 * Uninstalls the WSUWP A11y Status plugin.
+	 *
+	 * @since 0.7.0
+	 */
+	public static function uninstall() {
+		if ( ! current_user_can( 'activate_plugins' ) ) {
+			return;
+		}
+
+		if ( __FILE__ !== WP_UNINSTALL_PLUGIN ) {
+			return;
+		}
+
+		// Delete all user metadata saved by the plugin.
+		$users = get_users( array( 'fields' => array( 'ID' ) ) );
+
+		foreach ( $users as $user ) {
+			self::flush_a11y_status_usermeta( absint( $user->ID ) );
+		}
 	}
 
 	/**

--- a/includes/class-setup.php
+++ b/includes/class-setup.php
@@ -110,6 +110,7 @@ class WSUWP_A11y_Status {
 	 */
 	public function setup_hooks() {
 		add_action( 'wp_login', array( $this, 'update_a11y_status_usermeta' ), 10, 2 );
+		add_action( 'user_register', array( $this, 'update_a11y_status_by_user_id' ), 10, 1 );
 		add_action( 'admin_init', array( $this, 'handle_a11y_status_actions' ) );
 		add_action( 'admin_notices', array( $this, 'user_a11y_status_notice__remind' ) );
 		add_action( 'admin_notices', array( $this, 'user_a11y_status_notice__action' ) );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wsuwp-plugin-a11y-status",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/washingtonstateuniversity/wsuwp-plugin-a11y-status"

--- a/src/_css/main.css
+++ b/src/_css/main.css
@@ -2,7 +2,7 @@
 Plugin Name: WSUWP A11y Status
 Author: WSU University Communication, Adam Turner
 Author URI: https://web.wsu.edu/
-Version: 0.6.0
+Version: 0.7.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 */

--- a/wsuwp-a11y-status.php
+++ b/wsuwp-a11y-status.php
@@ -25,11 +25,12 @@ if ( ! defined( 'WPINC' ) ) {
 require_once __DIR__ . '/includes/class-setup.php';
 
 // Starts things up.
-add_action( 'after_setup_theme', 'load_wsuwp_a11y_status' );
+add_action( 'plugins_loaded', 'load_wsuwp_a11y_status' );
 
 // Flushes rules on activation and cleans up on deactivation.
 register_activation_hook( __FILE__, array( 'WSUWP_A11y_Status', 'activate' ) );
 register_deactivation_hook( __FILE__, array( 'WSUWP_A11y_Status', 'deactivate' ) );
+register_uninstall_hook( __FILE__, array( 'WSUWP_A11y_Status', 'uninstall' ) );
 
 /**
  * Creates an instance of the WSUWP A11y Status class.

--- a/wsuwp-a11y-status.php
+++ b/wsuwp-a11y-status.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Plugin Name: WSUWP A11y Status
-Version: 0.6.0
+Version: 0.7.0
 Description: A plugin to view users' WSU Accessibility Training status in the Admin area.
 Author: washingtonstateuniversity, Adam Turner
 Author URI: https://github.com/washingtonstateuniversity/


### PR DESCRIPTION
- Create methods to handle automatically fetching and updating the user metadata when the plugin is first activated (to populate the full usermeta data for the site) and when a user is created (to fetch that user's data).
- Create a method to remove the data set by the plugin on plugin uninstall (delete).

Also cleans up some of the instantiation and loading methods.